### PR TITLE
Update checkstyle.xml

### DIFF
--- a/koodi/viikko2/checkstyle.xml
+++ b/koodi/viikko2/checkstyle.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-
+    
+    <module name="LineLength"/>
     <module name="TreeWalker">
         <module name="JavadocMethod"/>
         <module name="JavadocType"/>
@@ -20,7 +21,6 @@
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
-        <module name="LineLength"/>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
         <module name="EmptyForIteratorPad"/>


### PR DESCRIPTION
Linelength ei stacktracen mukaan saanut olla TreeWalkerin sisällä. Tällaisena antoi tehdä checkin, ja Linelengthkin toimi tuonne siirrettynä ja ilmoitti ylipitkistä riveistä. Käytössä Gradle 6.0